### PR TITLE
Fix README link to `retext-emoji`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ them into separate nodes.
 
 This package is a tiny utility that helps when dealing with emoji and gemoji in
 natural language.
-The plugin [`retext-emoji`][retext-emoji] wraps this utility and others at a
+The plugin [`retext-emoji`][https://github.com/retextjs/retext-emoji] wraps this utility and others at a
 higher-level (easier) abstraction.
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ them into separate nodes.
 
 This package is a tiny utility that helps when dealing with emoji and gemoji in
 natural language.
-The plugin [`retext-emoji`][https://github.com/retextjs/retext-emoji] wraps this utility and others at a
+The plugin [`retext-emoji`][retext-emoji] wraps this utility and others at a
 higher-level (easier) abstraction.
 
 ## Install
@@ -209,7 +209,7 @@ abide by its terms.
 
 [coc]: https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md
 
-[retext-emoji]: https://github.com/syntax-tree/retext-emoji
+[retext-emoji]: https://github.com/retextjs/retext-emoji
 
 [nlcst]: https://github.com/syntax-tree/nlcst
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Fix README link to `retext-emoji` as it's in a separate org from this repo

<!--do not edit: pr-->
